### PR TITLE
Autoremove script when it finishes running

### DIFF
--- a/travis_check_secrets.sh
+++ b/travis_check_secrets.sh
@@ -27,3 +27,8 @@ docker container run --rm --name=gitleaks -e GITHUB_TOKEN=$GITLEAKS_GITHUB_ACCES
     -v $PWD/$final_config:/tmp/$final_config \
     $gitleaks_container --github-pr=https://github.com/$TRAVIS_REPO_SLUG/pull/$TRAVIS_PULL_REQUEST \
                         --config=/tmp/$final_config --verbose --redact
+
+# Autoremove this script when it finishes and maintain the exit code of the
+# gitleaks run
+exit_code=$?
+trap "rm -f $0; exit $exit_code;" EXIT


### PR DESCRIPTION
To avoid leaving the script laying around in the server, it is auto
removed when it finishes its execution. It's important that the exit
code is the one returned by the gitleaks run. Otherwise it'd always be 0
and the build would always pass, even if secrets were found.