### PR TITLE
fix: remove "api" from hardcoded credentials regex

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -113,7 +113,7 @@ title = "Global gitleaks config"
 	tags = ["key", "twilio"]
 [[rules]]
     description = "Hardcoded credentials"
-    regex = "(?i)(?:secret|api|key|signature|password|pwd|pass|token)(.{0,20})['|\"](.{10,120})['|\"]"
+    regex = "(?i)(?:secret|key|signature|password|pwd|pass|token)(.{0,20})['|\"](.{10,120})['|\"]"
     tags = ["credentials", "hardcoded"]
     [[rules.Entropies]]
         Min = "3"


### PR DESCRIPTION
There's some false positives triggered by having `api` in the Hardcoded Credentials regex. This PR removes it.