### PR TITLE
fix: moving "node_modules" to allowed paths

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -2,15 +2,16 @@ title = "Global gitleaks config"
 
 [allowlist]
 	description = "Allowlisted files"
-	files = ['''^\.?gitleaks.toml$''',
-		'''(.*?)(jpg|gif|doc|pdf|bin)$''',
-		'''(go.mod|go.sum)$''',
+	files = ['''^\.?gitleaks.toml$''', # Ignoring this file
+		'''(.*?)(jpg|gif|doc|pdf|bin)$''', # Ignoring common binaries
+		'''(go.mod|go.sum)$''', # Ignoring Go manifests
 		'''vendor\.json''',
 		'''Gopkg\.(lock|toml)''',
-		'''package-lock.json''',
-		'''yarn.lock''']
-	paths = ["node_modules"]
-	regexes = ['''test''']
+		'''package-lock\.json''', # Ignoring Node/JS manifests
+		'''package\.json''',
+		'''yarn\.lock''']
+	paths = ["node_modules"] # Ignoring Node dependencies
+	regexes = ['''test'''] # Ignoring lines with test
 
 [[rules]]
 	description = "AWS Manager ID"


### PR DESCRIPTION
Seems like we were not using well the `allowlist` property `files`.

`files` will evaluate only the filename and `path` will evaluate only the path. Now it seems obvious...