### PR TITLE
fix: adding allowlist field if missing

### DIFF
--- a/gitleaks_config_generator.py
+++ b/gitleaks_config_generator.py
@@ -42,7 +42,9 @@ def merge_config(global_config_path, local_config_path):
 
     for section, values in repo_config[allowlist_key].items():
         for value in values:
-            if value not in final_config["allowlist"][section]:
+            if section not in final_config["allowlist"]:
+                final_config["allowlist"][section] = value
+            elif value not in final_config["allowlist"][section]:
                 final_config["allowlist"][section].append(value)
 
     return final_config


### PR DESCRIPTION
This PR fixes an error on ` gitleaks_config_generator.py` generated by certain configurations.