### PR TITLE
[SEC-1411] fix: tuning go regexp rule to avoid detecting variable comparisons

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -146,7 +146,7 @@ title = "Global gitleaks config"
 [[rules]]
 	description = "Hardcoded credentials in Go files"
 	file = '''^(.*?)\.go$'''
-	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:.{0,20})(?:=|:=){1}(?:.{0,10})[\"'`](.{4,120})[\"'`]'''
+	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:\w|\s*?)(?:=|:=*?)(?:\s*?)[\"'`](.{4,120})[\"'`]'''
 	tags = ["credentials", "hardcoded", "go"]
 	[[rules.Entropies]]
 		Min = "3"

--- a/test_data/no_secrets/variable-comparison.go
+++ b/test_data/no_secrets/variable-comparison.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	var variables map[string]int {'a': 1, 'b': 2}
+	
+	for key := range variables {
+		// test that gitleaks does not detect the following line as a hardcoded variable
+		if key == "some_condition" || key == "different_condition" {
+			fmt.Println(key)
+		}
+	}
+}


### PR DESCRIPTION
Tuning the Go regexp rule to make it match variable assignations (`=` or `:=`) and not detect variable comparisons (e.g. `if key == 'something'`). To do that, I've replaced the following:
* Look up for a given amount of any characters `(?:.{0,20})` -> Look up for the minimum amount of either word chars or whitespace chars `(?:\w|\s*?)`
* Look up for one variable assignation `(?:=|:=){1}` -> Look up for the minimum amount of variable assignation `(?:=|:=*?)`
* Look up for a given amount of any characters `(?:.{0,10})` -> Look up for the minimum amount of whitespace chars `(?:\s*?)`

Adding a test case too.