### PR TITLE
feat(SP-960): adding rule for HCL files (.tf)

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -214,3 +214,16 @@ title = "Global gitleaks config"
 		Min = "4"
 		Max = "7"
 		Group = "1"
+
+[[rules]]
+	description = "Hardcoded credentials in HCL files (*.tf)"
+	file = '''^(.*?)\.tf$'''
+	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:.{0,20})(?:=){1}(?:\s)*?"(.{4,120})"'''
+	tags = ["credentials", "hardcoded", "hcl"]
+	[[rules.Entropies]]
+		Min = "3"
+		Max = "7"
+		Group = "1"
+	[rules.allowlist]
+		description = "Skip variable substitution"
+		regexes = ['''\${(?:.)*?}''']

--- a/test_data/no_secrets/terraform-config.tf
+++ b/test_data/no_secrets/terraform-config.tf
@@ -1,0 +1,28 @@
+resource "aws_db_instance" "postgres" {
+  identifier                 = "${var.environment}-${var.name}"
+  engine                     = "postgres"
+  engine_version             = "${var.postgres_version}"
+  instance_class             = "${var.instance_size}"
+  multi_az                   = "${var.multi_az}"
+  allocated_storage          = "${var.storage}"
+  storage_type               = "gp2"
+  username                   = "master"
+  password                   = "${random_password.master.result}"
+  apply_immediately          = "false"
+  skip_final_snapshot        = "true"
+  parameter_group_name       = "${aws_db_parameter_group.postgres.name}"
+  vpc_security_group_ids     = ["${aws_security_group.postgres.id}"]
+  db_subnet_group_name       = "${aws_db_subnet_group.db_subnet.name}"
+  backup_window              = "${var.with_backups == "true" ? var.backup_window : ""}"
+  backup_retention_period    = "${var.with_backups == "true" ? var.backup_retention_period : 0}"
+  maintenance_window         = "${var.with_backups == "true" ? var.maintenance_window : ""}"
+  kms_key_id                 = "${var.storage_encryption_arn}"
+  storage_encrypted          = "${var.storage_encryption_arn != "" ? true : false}"
+  auto_minor_version_upgrade = "false"
+  deletion_protection        = "true"
+
+  tags {
+    Env  = "${var.environment}"
+    Role = "${var.name}-database"
+  }
+}

--- a/test_data/secrets/terraform-config.tf
+++ b/test_data/secrets/terraform-config.tf
@@ -1,0 +1,16 @@
+resource "kubernetes_secret" "insights_dlq_db_credentials" {
+
+  metadata {
+    name      = "insights-dlq-db-credentials"
+    namespace = var.functions_namespace
+  }
+
+  data = {
+    username = "typeform"
+    password = "a3406ece8ff2ce6fb3ba6c3e89d918e2fe4dc"
+  }
+}
+
+data "aws_ssm_parameter" "insights_dlq_db_password" {
+  name = "${var.ssm_prefix}/secrets/insights_dlq_db_password"
+}


### PR DESCRIPTION
This one adds a new rule to `global_config.toml` that applies to HCL files (`*.tf`). It allowlists the variable assignations made to other variables (e.g. `variable = ${vars.whatever}`).

Edit: Adding test files too.