### PR TITLE
fix: avoiding false positive in JS rule

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -159,7 +159,7 @@ title = "Global gitleaks config"
 [[rules]]
 	description = "Hardcoded credentials in JavaScript files"
 	file = '''^(.*?)\.js$'''
-	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:.{0,20})(?:=){1}(?:\s{0,10})[\"'`](.{4,120})[\"'`]'''
+	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:\w|\s*?)(?:=){1}(?:\s{0,10})[\"'`](.{4,120})[\"'`]'''
 	tags = ["credentials", "hardcoded", "js"]
 	[[rules.Entropies]]
 		Min = "3"


### PR DESCRIPTION
Avoiding false positives by looking for words `\w` or whitespace characters `\s`.

The false positive was:
```
return !!formPublicKey && blockRef !== 'file_upload'
```