### PR TITLE
fix(SEC-1860): changing to lazy quantifier in JS rule

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -154,7 +154,7 @@ title = "Global gitleaks config"
 [[rules]]
 	description = "Hardcoded credentials in JavaScript files"
 	file = '''^(.*?)\.js$'''
-	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:\w|\s*?)(?:=){1}(?:\s{0,10})[\"'`](.{4,120})[\"'`]'''
+	regex = '''(?i)(?:secret|key|signature|password|pwd|pass|token)(?:\w|\s*?)(?:=){1}(?:\s{0,10})[\"'`](.*?)[\"'`]'''
 	tags = ["credentials", "hardcoded", "js"]
 	[[rules.Entropies]]
 		Min = "3"


### PR DESCRIPTION
Greedy quantifier in JS rule was capturing a bigger group than expected in multiple cases.