### PR TITLE
ci(SP-1222): adding semantic release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,18 @@ jobs:
       - name: Build image
         run: make build
 
-      - name: Push version images
+      - name: Semantic Release
+        id: semantic
+        if: github.event_name == 'push'
+        uses: codfish/semantic-release-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+       - name: Push version image
+        if: steps.semantic.outputs.new-release-published == 'true'
         run: make push
+        env:
+          RELEASE_TAG: ${{ steps.semantic.outputs.release-version }}
 
       - name: Push latest images
         if: contains(github.ref, 'refs/heads/master')

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 IMAGE_NAME := "quay.io/typeform/gitleaks-config"
-VERSION ?= dev
+RELEASE_TAG ?= dev
 
 all: build run
 
 build:
-	docker build -t $(IMAGE_NAME):${VERSION} -t $(IMAGE_NAME):latest .
+	docker build -t $(IMAGE_NAME):${RELEASE_TAG} -t $(IMAGE_NAME):latest .
 
 run:
 	docker container run --rm -v ${PWD}/.gitleaks.toml:/app/.gitleaks.toml \
-		$(IMAGE_NAME):${VERSION}
+		$(IMAGE_NAME):${RELEASE_TAG}
 
 test-config-generator: build
 	docker container run --rm -v ${PWD}/test/local-config.toml:/app/local-config.toml \
 		-v ${PWD}/test/local-config-old.toml:/app/local-config-old.toml \
-		$(IMAGE_NAME):${VERSION} \
+		$(IMAGE_NAME):${RELEASE_TAG} \
 		python gitleaks_config_generator_tests.py
 
 test-gitleaks-config:
@@ -22,7 +22,7 @@ test-gitleaks-config:
 test: test-config-generator test-gitleaks-config
 
 push:
-	docker push $(IMAGE_NAME):${VERSION}
+	docker push $(IMAGE_NAME):${RELEASE_TAG}
 
 push-latest:
 	docker push $(IMAGE_NAME):latest


### PR DESCRIPTION
Using `codfish/semantic-release-action@v1` to publish and tag Docker images with semantic versioning.