### PR TITLE
feat(php): Ignore composer manifests

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -11,6 +11,8 @@ title = "Global gitleaks config"
 		'''Gopkg\.(lock|toml)''',
 		'''package-lock\.json''', # Ignoring Node/JS manifests
 		'''package\.json''',
+		'''composer\.json''',
+		'''composer\.lock''', #Ignoring PHP manifests
 		'''yarn\.lock''']
 	paths = ["node_modules", # Ignoring Node dependencies
 		"vendor", # Ignoring Go dependencies


### PR DESCRIPTION
Adds rules to ignore both `composer.json` and `composer.lock`