### PR TITLE
chore(SP-1220): updating branch name in ci-standard-checks

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -2,11 +2,11 @@ name: CI Standard Checks
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:
-      - master
+      - main
 
 jobs:
   ci-standard-checks:


### PR DESCRIPTION
We still had `master` as the name for the base branch.