### PR TITLE
build(NOJIRA-1234): migrate GHA runners to ephemeral

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci-standard-checks:
-    runs-on: [self-hosted, automated-checks]
+    runs-on: [self-hosted, automated-checks-ephemeral]
 
     steps:
       - name: Check Out Source Code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Run tests and build
-    runs-on: [self-hosted, bear]
+    runs-on: [self-hosted, bear-ephemeral]
 
     steps:
 


### PR DESCRIPTION
Updates GHA runners to ephemeral runners. For more info check [this](https://www.notion.so/typeform/Migration-to-Ephemeral-runners-ffd85bafaed44cfd8a0c135701c4a6a7)

[_Created by Sourcegraph batch change `bruno.ferreira/migrate-gha-runners-to-ephemeral`._](https://sourcegraph.tools.typeform.tf/users/bruno.ferreira/batch-changes/migrate-gha-runners-to-ephemeral)