### PR TITLE
chore(SP-2203): use correct token

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -22,5 +22,5 @@ jobs:
         uses: Typeform/ci-standard-checks@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          dockerUsername: ${{ secrets.DOCKER_USERNAME }}
-          dockerPassword: ${{ secrets.DOCKER_PASSWORD }}
+          dockerUsername: ${{ secrets.GITLEAKS_DOCKER_USERNAME }}
+          dockerPassword: ${{ secrets.GITLEAKS_DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,4 +48,4 @@ jobs:
             ]
           tag_format: '${version}'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updated the CI to use `GITHUB_TOKEN` which has Read and Write permissions for this repository.