### PR TITLE
feat(SEC-4542): match entire line in allowlist regex

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -7,6 +7,7 @@ useDefault = true
 
 [allowlist]
 description = "Global allowlisted paths, files, and stopwords"
+regexTarget = "line" # gitleaks defaults to matching the Secret, let's change it to match the entire line (added in gitleaks v8.16.0)
 paths = [
   '''\.gitleaks\.toml$''', # Ignoring the generated configuration file
   '''(.*?)(jpg|gif|doc|pdf|bin)$''', # Ignoring common binaries


### PR DESCRIPTION
This PR makes `gitleaks` match the entire line when evaluating an allowlist regex. By default it does match the Secret which makes certain allowlist regexes fail. The `gitleaks` flag `regexTarget` [was introduced in v8.16.0](https://github.com/gitleaks/gitleaks/releases/tag/v8.16.0).

This behavior seems like it's the expected one by our developers so let's keep it as the default. If some repository needs a different one we can always add the parameter `regexTarget` as something that developers can tune through  `.gitleaks.toml` and it's read by [gitleaks_config_generator.py](https://github.com/Typeform/gitleaks-config/blob/39a7e533c36daf8b96dc8b22a604db3c81b3ac0a/gitleaks_config_generator.py).