### PR TITLE
add an exeption for catalog-info.yaml files

### DIFF
--- a/global_config.toml
+++ b/global_config.toml
@@ -27,6 +27,7 @@ paths = [
   '''node_modules\/''', # Ignoring Node dependencies
   '''vendor\/''', # Ignoring Go dependencies
   '''test(|s)\/''', # Ignoring test directories
+  '''catalog-info\.(yaml|yml)''', # Ignoring Developer console configuration files
 ]
 
 # A more precise rule to detect Typeform API tokens


### PR DESCRIPTION
Testing a bulk PR for adding this file in forms-api, breaks the build because of a false positive.

Because we are going to do a bulk PR adding this file to all repositories, and this file will never need have any kind of secrets,  I thought it would be a good idea to skip it. 

This file will be added automatically in all repositories, hence the idea

This is the Action prompt
<img width="1033" alt="CleanShot 2023-07-31 at 18 03 12@2x" src="https://github.com/Typeform/gitleaks-config/assets/36204321/effafa1c-038a-46c4-a7e3-ac3a10bbf3c7">

This is the line giving the false positive:
https://github.com/Typeform/forms-api/blob/40a327bdaf24a956fc1e51c46b6edea645812a5e/catalog-info.yaml#L21
