### PR TITLE
docs(badges): add standard badges to README [PR-41]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a href=https://engineering-metrics.typeform.tf/standards-adoption-tool/reports/gitleaks-config/><img src=https://api.typeform.com/repositories/gitleaks-config/badges.svg /></a>
 # gitleaks-config
 
 [![Build Status](https://github.com/Typeform/gitleaks-config/actions/workflows/ci.yaml/badge.svg)](https://github.com/Typeform/gitleaks-config/actions/workflows/ci.yaml)


### PR DESCRIPTION
Add new badges img to repository

[_Created by Sourcegraph batch change `engineering-intelligence/PR-41-update-repo-badges-img-no-previous-badge`._](https://sourcegraph.tools.typeform.tf/users/engineering-intelligence/batch-changes/PR-41-update-repo-badges-img-no-previous-badge)