### PR TITLE
feat(NOJIRA-1234): support multiarch and bump python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,31 @@ test-gitleaks-config:
 
 test: test-config-generator test-gitleaks-config
 
-build-public-ecr: build
+build-amd64:
+	docker buildx build \
+		--platform linux/amd64 \
+		-t $(IMAGE_NAME):${IMAGE_TAG}-amd64 \
+		--load \
+		.
 
-push-public-ecr:
-	docker push $(IMAGE_NAME):${IMAGE_TAG}
+build-arm64:
+	docker buildx build \
+		--platform linux/arm64 \
+		-t $(IMAGE_NAME):${IMAGE_TAG}-arm64 \
+		--load \
+		.
+
+build-multiarch-local: build-amd64 build-arm64
+
+push-multiarch:
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		-t $(IMAGE_NAME):${IMAGE_TAG} \
+		-t $(IMAGE_NAME):latest \
+		--push \
+		.
+
+# Public ECR Jenkins file required targets
+build-public-ecr: build-multiarch-local
+
+push-public-ecr: push-multiarch


### PR DESCRIPTION
- Bumping container image version to latest stable
- Adding support for multiarch (`linux/arm64/v8`) while keeping [Public ECR Jenkins file required targets](https://www.notion.so/typeform/Public-ECR-20d23dfc4c0080958dd0ec2da03a9575?source=copy_link#20d23dfc4c00812a8928c60460e4dfc7)