### PR TITLE
security(NOJIRA-1234): replace compromised codfish/semantic-release-a…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Semantic Release
         id: semantic
         if: github.event_name == 'push'
-        uses: codfish/semantic-release-action@v1
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
           branches: |
             ['main']


### PR DESCRIPTION
## Why

`codfish/semantic-release-action` was the target of [a supply chain attack
on 2026-06-24](https://www.aikido.dev/blog/compromised-github-action-codfish-steals-secrets) — its version tags (`v2`–`v5`) were repointed to a commit
containing a credential-stealing payload (the Miasma toolkit), targeting
`GITHUB_TOKEN` and `NPM_TOKEN` secrets in CI runners. The upstream
repository has since been disabled by GitHub for ToS violations.

This PR replaces it with `cycjimmy/semantic-release-action`, a
well-maintained, widely-used alternative, **pinned to a commit SHA**
rather than a floating tag, to remove this class of risk going forward.

## What changed

- `codfish/semantic-release-action@vX` → `cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90` (v6.0.0)

## Verification

No functional change is expected — `cycjimmy/semantic-release-action`
exposes the same inputs/outputs/env var contract (`GITHUB_TOKEN`,
`NPM_TOKEN`, `branches`, `extra_plugins`, etc.) as the action it replaces.
Please re-run this workflow on a test branch before merging to confirm.

[_Created by Sourcegraph batch change `david.salvador/replace-codfish-semantic-release-action`._](https://typeform.sourcegraphcloud.com/users/david.salvador/batch-changes/replace-codfish-semantic-release-action)